### PR TITLE
Log cloud id and assignment id for assignments

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.3
 commit = True
 tag = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ project = "quads-lib"
 year = "2025"
 author = "Gonzalo Rafuls"
 copyright = f"{year}, {author}"
-version = release = "0.1.1"
+version = release = "0.1.3"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(*names, **kwargs):
 
 setup(
     name="quads-lib",
-    version="0.1.1",
+    version="0.1.3",
     license="LGPL-3.0-only",
     description="Python client library for interacting with the QUADS API",
     long_description="{}\n{}".format(

--- a/src/quads_lib/__init__.py
+++ b/src/quads_lib/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1"
+__version__ = "0.1.3"
 
 from .quads import QuadsApi
 

--- a/src/quads_lib/quads.py
+++ b/src/quads_lib/quads.py
@@ -201,12 +201,18 @@ class QuadsApi(QuadsBase):
     # Assignments
     @returns("Assignment")
     def create_assignment(self, data: dict) -> dict:
-        return self.post("assignments", data)
+        response = self.post("assignments", data)
+        if response and {"id", "cloud"} <= response.keys():
+            print(f"Assignment created - ID: {response['id']}, Cloud: {response['cloud']['name']}")
+        return response
 
     @returns("Assignment")
     def create_self_assignment(self, data: dict) -> dict:
         endpoint = Path("assignments") / "self"
-        return self.post(str(endpoint), data)
+        response = self.post(str(endpoint), data)
+        if response and {"id", "cloud"} <= response.keys():
+            print(f"Self-assignment created - ID: {response['id']}, Cloud: {response['cloud']['name']}")
+        return response
 
     @returns("Assignment")
     def update_assignment(self, assignment_id: int, data: dict) -> dict:

--- a/tests/test_quads.py
+++ b/tests/test_quads.py
@@ -1687,7 +1687,7 @@ class TestQuadsApi:
             "cloud": {"name": "cloud1", "owner": "user1"},
             "host": "host1",
             "start": "2025-06-20",
-            "end": "2025-06-21"
+            "end": "2025-06-21",
         }
 
         mock_response = Mock()
@@ -1704,12 +1704,7 @@ class TestQuadsApi:
     def test_create_assignment_no_logging(self, mock_request, mock_print):
         assignment_data = {"cloud": "cloud1", "host": "host1", "start": "2025-06-20", "end": "2025-06-21"}
         # Missing 'id' field in response - should not trigger logging
-        response_data = {
-            "cloud": {"name": "cloud1", "owner": "user1"},
-            "host": "host1",
-            "start": "2025-06-20",
-            "end": "2025-06-21"
-        }
+        response_data = {"cloud": {"name": "cloud1", "owner": "user1"}, "host": "host1", "start": "2025-06-20", "end": "2025-06-21"}
 
         mock_response = Mock()
         mock_response.status_code = 200
@@ -1725,11 +1720,7 @@ class TestQuadsApi:
     def test_create_assignment_limit_reached(self, mock_request, mock_print):
         assignment_data = {"cloud": "cloud1", "host": "host1", "start": "2025-06-20", "end": "2025-06-21"}
         # Error response for scheduling limit reached
-        error_response = {
-            'error': 'Forbidden',
-            'message': 'Self scheduling limit reached',
-            'status_code': 403
-        }
+        error_response = {"error": "Forbidden", "message": "Self scheduling limit reached", "status_code": 403}
 
         mock_response = Mock()
         mock_response.status_code = 403
@@ -1745,12 +1736,7 @@ class TestQuadsApi:
     @patch("requests.Session.request")
     def test_create_self_assignment_logging(self, mock_request, mock_print):
         assignment_data = {"cloud": "cloud1", "start": "2025-06-20", "end": "2025-06-21"}
-        response_data = {
-            "id": 123,
-            "cloud": {"name": "cloud1", "owner": "user1"},
-            "start": "2025-06-20",
-            "end": "2025-06-21"
-        }
+        response_data = {"id": 123, "cloud": {"name": "cloud1", "owner": "user1"}, "start": "2025-06-20", "end": "2025-06-21"}
 
         mock_response = Mock()
         mock_response.status_code = 200
@@ -1766,11 +1752,7 @@ class TestQuadsApi:
     def test_create_self_assignment_no_logging(self, mock_request, mock_print):
         assignment_data = {"cloud": "cloud1", "start": "2025-06-20", "end": "2025-06-21"}
         # Missing 'cloud' field in response - should not trigger logging
-        response_data = {
-            "id": 123,
-            "start": "2025-06-20",
-            "end": "2025-06-21"
-        }
+        response_data = {"id": 123, "start": "2025-06-20", "end": "2025-06-21"}
 
         mock_response = Mock()
         mock_response.status_code = 200
@@ -1786,11 +1768,7 @@ class TestQuadsApi:
     def test_create_self_assignment_limit_reached(self, mock_request, mock_print):
         assignment_data = {"cloud": "cloud1", "start": "2025-06-20", "end": "2025-06-21"}
         # Error response for self scheduling limit reached
-        error_response = {
-            'error': 'Forbidden',
-            'message': 'Self scheduling limit reached',
-            'status_code': 403
-        }
+        error_response = {"error": "Forbidden", "message": "Self scheduling limit reached", "status_code": 403}
 
         mock_response = Mock()
         mock_response.status_code = 403
@@ -1801,6 +1779,7 @@ class TestQuadsApi:
 
         mock_print.assert_not_called()
         assert result == error_response
+
 
 class TestQuadsBase:
     @pytest.fixture

--- a/tests/test_quads.py
+++ b/tests/test_quads.py
@@ -1678,6 +1678,129 @@ class TestQuadsApi:
 
         assert self.api.token == "existing-token"
 
+    @patch("builtins.print")
+    @patch("requests.Session.request")
+    def test_create_assignment_logging(self, mock_request, mock_print):
+        assignment_data = {"cloud": "cloud1", "host": "host1", "start": "2025-06-20", "end": "2025-06-21"}
+        response_data = {
+            "id": 42,
+            "cloud": {"name": "cloud1", "owner": "user1"},
+            "host": "host1",
+            "start": "2025-06-20",
+            "end": "2025-06-21"
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = response_data
+        mock_request.return_value = mock_response
+
+        self.api.create_assignment(assignment_data)
+
+        mock_print.assert_called_once_with("Assignment created - ID: 42, Cloud: cloud1")
+
+    @patch("builtins.print")
+    @patch("requests.Session.request")
+    def test_create_assignment_no_logging(self, mock_request, mock_print):
+        assignment_data = {"cloud": "cloud1", "host": "host1", "start": "2025-06-20", "end": "2025-06-21"}
+        # Missing 'id' field in response - should not trigger logging
+        response_data = {
+            "cloud": {"name": "cloud1", "owner": "user1"},
+            "host": "host1",
+            "start": "2025-06-20",
+            "end": "2025-06-21"
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = response_data
+        mock_request.return_value = mock_response
+
+        self.api.create_assignment(assignment_data)
+
+        mock_print.assert_not_called()
+
+    @patch("builtins.print")
+    @patch("requests.Session.request")
+    def test_create_assignment_limit_reached(self, mock_request, mock_print):
+        assignment_data = {"cloud": "cloud1", "host": "host1", "start": "2025-06-20", "end": "2025-06-21"}
+        # Error response for scheduling limit reached
+        error_response = {
+            'error': 'Forbidden',
+            'message': 'Self scheduling limit reached',
+            'status_code': 403
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 403
+        mock_response.json.return_value = error_response
+        mock_request.return_value = mock_response
+
+        result = self.api.create_assignment(assignment_data)
+
+        mock_print.assert_not_called()
+        assert result == error_response
+
+    @patch("builtins.print")
+    @patch("requests.Session.request")
+    def test_create_self_assignment_logging(self, mock_request, mock_print):
+        assignment_data = {"cloud": "cloud1", "start": "2025-06-20", "end": "2025-06-21"}
+        response_data = {
+            "id": 123,
+            "cloud": {"name": "cloud1", "owner": "user1"},
+            "start": "2025-06-20",
+            "end": "2025-06-21"
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = response_data
+        mock_request.return_value = mock_response
+
+        self.api.create_self_assignment(assignment_data)
+
+        mock_print.assert_called_once_with("Self-assignment created - ID: 123, Cloud: cloud1")
+
+    @patch("builtins.print")
+    @patch("requests.Session.request")
+    def test_create_self_assignment_no_logging(self, mock_request, mock_print):
+        assignment_data = {"cloud": "cloud1", "start": "2025-06-20", "end": "2025-06-21"}
+        # Missing 'cloud' field in response - should not trigger logging
+        response_data = {
+            "id": 123,
+            "start": "2025-06-20",
+            "end": "2025-06-21"
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = response_data
+        mock_request.return_value = mock_response
+
+        self.api.create_self_assignment(assignment_data)
+
+        mock_print.assert_not_called()
+
+    @patch("builtins.print")
+    @patch("requests.Session.request")
+    def test_create_self_assignment_limit_reached(self, mock_request, mock_print):
+        assignment_data = {"cloud": "cloud1", "start": "2025-06-20", "end": "2025-06-21"}
+        # Error response for self scheduling limit reached
+        error_response = {
+            'error': 'Forbidden',
+            'message': 'Self scheduling limit reached',
+            'status_code': 403
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 403
+        mock_response.json.return_value = error_response
+        mock_request.return_value = mock_response
+
+        result = self.api.create_self_assignment(assignment_data)
+
+        mock_print.assert_not_called()
+        assert result == error_response
 
 class TestQuadsBase:
     @pytest.fixture


### PR DESCRIPTION
Kinda limited for checks, let me know.
Also print standard unkown.

Fixes: https://github.com/quadsproject/python-quads-lib/issues/7