### PR TITLE
fix: remove synthetic 201, use pure password or token login calls.

### DIFF
--- a/src/quads_lib/quads.py
+++ b/src/quads_lib/quads.py
@@ -22,13 +22,6 @@ class QuadsApi(QuadsBase):
         return json_response
 
     def login(self) -> dict:
-        if self.token and self.token.startswith("qat_"):
-            return {
-                "status_code": 201,
-                "status": "success",
-                "message": "Authenticated via API token",
-                "auth_token": self.token,
-            }
         endpoint = urljoin(self.base_url, "login")
         _response = self.session.post(endpoint, auth=self.auth, verify=self.verify)
         json_response = _response.json()

--- a/tests/test_quads.py
+++ b/tests/test_quads.py
@@ -2083,20 +2083,11 @@ class TestApiTokenAuth:
         assert api.token is None
         assert api.auth is not None
 
-    def test_login_noop_with_qat_token(self):
-        """Test that login() returns synthetic success for qat_ tokens"""
+    def test_api_token_skips_login(self):
+        """Test that api_token users should not call login() - token is already on the session"""
         api = QuadsApi("", "", "http://example.com/", api_token="qat_abc123")
-        result = api.login()
-        assert result["status_code"] == 201
-        assert result["status"] == "success"
-        assert result["auth_token"] == "qat_abc123"
-
-    def test_login_noop_does_not_make_request(self):
-        """Test that login() with qat_ token makes no HTTP request"""
-        api = QuadsApi("", "", "http://example.com/", api_token="qat_abc123")
-        api.session.post = Mock(side_effect=AssertionError("should not be called"))
-        result = api.login()
-        assert result["status"] == "success"
+        assert api.token == "qat_abc123"
+        assert api.session.headers.get("Authorization") == "Bearer qat_abc123"
 
     @patch("requests.Session.request")
     def test_get_user(self, mock_request):


### PR DESCRIPTION
  quads-lib: Removed the fake 201 from login(). The method is now a pure password-login call again. When api_token is used, the token is already on  the session from __init__() — callers should not call login() at all.